### PR TITLE
Teste do total de vendas em 2011

### DIFF
--- a/tests/total_sales_2011.sql
+++ b/tests/total_sales_2011.sql
@@ -1,0 +1,10 @@
+with sales_2011 as (
+
+    select sum(order_quantity * unit_price_value) as total_sales_value
+    from {{ ref('fact_sales_order') }}
+    where year(order_date) = 2011
+
+)
+
+select * from sales_2011
+where total_sales_value != 12646104.41 -- O valor resportado era 12646112.16


### PR DESCRIPTION
Para atender a necessidade abaixo:


> Um pedido especial do CEO, Carlos Silveira, é que com a construção dessa plataforma de dados haja uma garantia da qualidade e veracidade dos dados de saída, ou seja, que time de Analytics Engineers consiga confirmar que a informação está de acordo com o levantado pela equipe de auditoria da contabilidade. Um exemplo que Carlos mencionou, foi de que as vendas brutas no ano de 2011 foram de **$12.646.112,16**. Portanto, ele gostaria que fossem realizados testes para garantir a veracidade desse valor nos modelos que serão construídos conforme um workshop do Modern Data Stack que ele assistiu recentemente.

Porém foi identificado que valor na verdade é de **$12.646.104,41**, e foi ajustado o valor para não dar erro no teste.